### PR TITLE
test: fix test runs

### DIFF
--- a/Sources/GitKit/Git.swift
+++ b/Sources/GitKit/Git.swift
@@ -16,7 +16,7 @@ public final class Git: Shell {
         case cmd(Command, String? = nil)
         case addAll
         case status(short: Bool = false)
-        case commit(message: String, Bool = false)
+        case commit(message: String, allowEmpty: Bool = false, gpgSigned: Bool = false)
         case config(name: String, value: String)
         case clone(url: String)
         case checkout(branch: String, create: Bool = false)
@@ -52,10 +52,15 @@ public final class Git: Shell {
                 if short {
                     params.append("--short")
                 }
-            case .commit(let message, let allowEmpty):
+            case .commit(let message, let allowEmpty, let gpgSigned):
                 params = [Command.commit.rawValue, "-m", "\"\(message)\""]
                 if allowEmpty {
                     params.append("--allow-empty")
+                }
+                if gpgSigned {
+                    params.append("--gpg-sign")
+                } else {
+                    params.append("--no-gpg-sign")
                 }
             case .clone(let url):
                 params = [Command.clone.rawValue, url]

--- a/Tests/GitKitTests/GitKitTests.swift
+++ b/Tests/GitKitTests/GitKitTests.swift
@@ -82,15 +82,15 @@ final class GitKitTests: XCTestCase {
     func testCommandWithArgs() throws {
         let path = self.currentPath()
 
-        try self._test(.cmd(.branch, "-a"), path: path, expectation: "* master")
+        try self._test(.cmd(.branch, "-a"), path: path, expectation: "* main")
     }
     
     func testClone() throws {
         let path = self.currentPath()
         
         let expectation = """
-            On branch master
-            Your branch is up to date with 'origin/master'.
+            On branch main
+            Your branch is up to date with 'origin/main'.
 
             nothing to commit, working tree clean
             """
@@ -109,7 +109,7 @@ final class GitKitTests: XCTestCase {
         let path = self.currentPath()
         try self.clean(path: path)
         let expectedOutput = """
-            On branch master
+            On branch main
             nothing to commit, working tree clean
             """
         

--- a/Tests/GitKitTests/GitKitTests.swift
+++ b/Tests/GitKitTests/GitKitTests.swift
@@ -74,7 +74,7 @@ final class GitKitTests: XCTestCase {
         let git = Git(path: path)
         try git.run(.cmd(.initialize))
         try git.run(.commit(message: expectation, true))
-        let out = try git.run(.log(1))
+        let out = try git.run(.log(numberOfCommits: 1))
         try self.clean(path: path)
         XCTAssertTrue(out.hasSuffix(expectation), "Commit was not created.")
     }

--- a/Tests/GitKitTests/GitKitTests.swift
+++ b/Tests/GitKitTests/GitKitTests.swift
@@ -49,7 +49,7 @@ final class GitKitTests: XCTestCase {
         try self.clean(path: path)
         let expectedOutput = expectation
         let git = Git(path: path)
-        try git.run(.raw("init && git commit -m 'initial' --allow-empty"))
+        try git.run(.raw("init && git commit -m 'initial' --allow-empty --no-gpg-sign"))
         let output = try git.run(alias)
         self.assert(type: "output", result: output, expected: expectedOutput)
         try self.clean(path: path)
@@ -73,7 +73,7 @@ final class GitKitTests: XCTestCase {
         try self.clean(path: path)
         let git = Git(path: path)
         try git.run(.cmd(.initialize))
-        try git.run(.commit(message: expectation, true))
+        try git.run(.commit(message: expectation, allowEmpty: true))
         let out = try git.run(.log(numberOfCommits: 1))
         try self.clean(path: path)
         XCTAssertTrue(out.hasSuffix(expectation), "Commit was not created.")
@@ -114,7 +114,7 @@ final class GitKitTests: XCTestCase {
             """
         
         let git = Git(path: path)
-        try git.run(.raw("init && git commit -m 'initial' --allow-empty"))
+        try git.run(.raw("init && git commit -m 'initial' --allow-empty --no-gpg-sign"))
         
         let expectation = XCTestExpectation(description: "Shell command finished.")
         git.run(.cmd(.status)) { result, error in


### PR DESCRIPTION
I was hitting a couple issues trying to run the tests:
- wouldn't compile, I guess when they were written there was no `numberOfCommits:` param label and it was added later 
    - **note:** i took the opportunity to also label the param that affected `allowEmpty`, so that's actually a breaking change if you care
- it would lock up on the gpg signature modal my machine requires.
- tests refer to the `master` branch but the default branch is `main` so they'd fail 